### PR TITLE
Update runtime to 50

### DIFF
--- a/net.codelogistics.webapps.json
+++ b/net.codelogistics.webapps.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.codelogistics.webapps",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "webapps",
     "finish-args": [
@@ -16,13 +16,8 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+        "/share/gir-1.0",
+        "/share/vala"
     ],
     "modules": [
         {
@@ -37,11 +32,11 @@
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal.git",
                     "tag": "0.9.1",
+                    "commit": "8f5dc8d192f6e31dafe69e35219e3b707bde71ce",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "8f5dc8d192f6e31dafe69e35219e3b707bde71ce"
+                    }
                 }
             ]
         },
@@ -54,11 +49,11 @@
                     "type": "git",
                     "url": "https://codeberg.org/eyekay/webapps.git",
                     "tag": "0.6.0",
+                    "commit": "7482f2c5efd09d2720d08daba43b495c0546f6f1",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "7482f2c5efd09d2720d08daba43b495c0546f6f1"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size
- Move the commit entries to under the tag entries